### PR TITLE
Add nix flake for sugarjazy

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -1,0 +1,12 @@
+name: "Build legacy Nix package on Ubuntu"
+
+on: [push, pull_request]
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - name: Building package
+        run: nix-build . -A defaultPackage.x86_64-linux

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ You can install it [from aur](https://aur.archlinux.org/packages/sugarjazy) with
 yay -S sugarjazy
 ```
 
+### Nix
+
+This is publish as a "[flake](https://github.com/NixOS/rfcs/pull/49)"
+and thus can be used with recent version of `nix` as following:
+
+```
+nix run github:chmouel/sugarjazy -- [flags]
+```
+
+*Note: `nix flake` is still an experimental command and might not be
+available on all supported nixos version.*
+
 ### pip
 
 With pip from pypi - <https://pypi.org/project/sugarjazy/>

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1649497218,
+        "narHash": "sha256-groqC9m1P4hpnL6jQvZ3C8NEtduhdkvwGT0+0LUrcYw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fd364d268852561223a5ada15caad669fd72800e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    let out = system:
+      let pkgs = nixpkgs.legacyPackages."${system}";
+      in
+      {
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            python310Packages.poetry
+          ];
+        };
+
+        defaultPackage = with pkgs.poetry2nix; mkPoetryApplication {
+          projectDir = ./.;
+          preferWheels = true;
+          python = pkgs.python310;
+        };
+
+        defaultApp = utils.lib.mkApp {
+          drv = self.defaultPackage."${system}";
+        };
+
+      }; in with utils.lib; eachSystem defaultSystems out;
+
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
Add support of nix flakes for sugarjazy.

This will, for example, allow a user to do :

```
kubectl logs […] | nix run github:chmouel/sugarjazy -- -s
```

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
